### PR TITLE
update action steps, use apt-get

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v4
         with:
           lfs: true
 
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install and Build 🔧
         run: |
-          sudo apt update && sudo apt install reprepro python3 python3-pip
+          sudo apt-get update && sudo apt-get -y install reprepro python3 python3-pip
           pip3 install mako
 
           # import keys
@@ -34,7 +34,7 @@ jobs:
           python3 createStaticDirectoryListing.py deploy --indexPage README.md
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           branch: deploy
           folder: deploy


### PR DESCRIPTION
- use apt-get rather than apt to stop warnings
- upgrade to checkout@v4, might fix action api deprecation warnings
- upgrade to current github-pages-deploy-action