### PR TITLE
update repo location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ curl -fsSL https://apt.lib.umich.edu/mlibrary-archive-keyring.gpg -o /etc/apt/ke
 ```
 2. Add repo:
 ```bash
-echo "deb [signed-by=/etc/apt/keyrings/mlibrary-archive-keyring.gpg] https://apt.lib.umich.edu/github-pages-dep-repo bullseye main" > /etc/apt/sources.list.d/mlibrary.list
+echo "deb [signed-by=/etc/apt/keyrings/mlibrary-archive-keyring.gpg] https://apt.lib.umich.edu bullseye main" > /etc/apt/sources.list.d/mlibrary.list
 ```
 3. Apt update
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ curl -fsSL https://apt.lib.umich.edu/mlibrary-archive-keyring.gpg -o /etc/apt/ke
 ```
 2. Add repo:
 ```bash
-echo "deb [signed-by=/etc/apt/keyrings/mlibrary-archive-keyring.gpg] https://apt.lib.umich.edu bullseye main" > /etc/apt/sources.list.d/mlibrary.list
+echo "deb [signed-by=/etc/apt/keyrings/mlibrary-archive-keyring.gpg] https://apt.lib.umich.edu $(grep -m1 '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2) main" > /etc/apt/sources.list.d/mlibrary.list
 ```
 3. Apt update
 ```bash


### PR DESCRIPTION
mrio and antmoth just tried using this for bookworm grok, and apt claimed that the repository had no Release file. Making this change fixed it and everything installed normally