### PR TITLE
disable lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
-*.tar.gz filter=lfs diff=lfs merge=lfs -text
-*.dsc filter=lfs diff=lfs merge=lfs -text
-*.deb filter=lfs diff=lfs merge=lfs -text
-*.buildinfo filter=lfs diff=lfs merge=lfs -text
-*.changes filter=lfs diff=lfs merge=lfs -text
+#*.tar.gz filter=lfs diff=lfs merge=lfs -text
+#*.deb filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Disable lfs filters in .gitattributes so we don't start accidentally adding new debs to lfs.

- if/when we move debs to lfs it should be intentional, so comment out lines for .deb, .tar.gz
- putting non-binary non-large files in lfs makes no sense, so delete those lines